### PR TITLE
Add failed scheduled jobs RabbitMQ queue

### DIFF
--- a/components/jobcreator/base/jobcreator.yml
+++ b/components/jobcreator/base/jobcreator.yml
@@ -37,6 +37,8 @@ spec:
           value: rabbitmq-cluster.rabbitmq-system.svc.cluster.local
         - name: INGRESS_QUEUE_NAME
           value: scheduled-jobs
+        - name: FAILURE_QUEUE_NAME
+          value: failed-scheduled-jobs
         - name: DEFAULT_RUNNER_SHA
           value: 6e5f2d070bb67742f354948d68f837a740874d230714eaa476d35ab6ad56caec
         - name: WATCHER_SHA

--- a/components/rabbitmq-messaging-topology/base/queues.yml
+++ b/components/rabbitmq-messaging-topology/base/queues.yml
@@ -38,3 +38,16 @@ spec:
   durable: true
   rabbitmqClusterReference:
     name: rabbitmq-cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: failed-scheduled-jobs
+  namespace: rabbitmq-system
+spec:
+  name: failed-scheduled-jobs
+  type: quorum
+  autoDelete: false
+  durable: true
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster


### PR DESCRIPTION
Closes None.

## Summary
- Add the `failed-scheduled-jobs` RabbitMQ quorum queue
- Configure jobcreator with `FAILURE_QUEUE_NAME=failed-scheduled-jobs`

## Testing
- `kubectl kustomize components\rabbitmq-messaging-topology\base`
- `kubectl kustomize components\jobcreator\base`

## Jobcontroller change
https://github.com/fiaisis/jobcontroller/pull/435